### PR TITLE
Ajuste em problema de conexão

### DIFF
--- a/lib/BleManager/Ble.cpp
+++ b/lib/BleManager/Ble.cpp
@@ -10,10 +10,7 @@ void Ble::start() {
   uint8_t controller = 0;
 
   // Create the BLE Device
-  preferences.begin("info", false);
-  String deviceName = preferences.getString("deviceName", DEFAUT_DEVICE_NAME);
-  preferences.end();
-  BLEDevice::init(deviceName);
+  BLEDevice::init(DEFAUT_DEVICE_NAME);
 
   // Create the BLE Server
   BLEServer *pServer = BLEDevice::createServer();


### PR DESCRIPTION
Bluetooth não conecta quando nome do dispositivo vem da preferences. (Verificar se é por padrão de nomeclatura, etc)